### PR TITLE
Created an alias Client#invoices of Client#invoice method

### DIFF
--- a/lib/fakturownia/client.rb
+++ b/lib/fakturownia/client.rb
@@ -12,5 +12,6 @@ module Fakturownia
     def invoice
       Fakturownia::Api::Invoice.new(self)
     end
+    alias_method :invoices, :invoice
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -19,4 +19,11 @@ describe Fakturownia::Client do
       subject.invoice
     end
   end
+
+  describe '#invoices' do
+    it 'is an alias of #invoice' do
+      expect(subject.invoices).to be_instance_of(subject.invoice.class)
+      expect(subject.invoices.client).to be(subject.invoice.client)
+    end
+  end
 end


### PR DESCRIPTION
Using plural relation between `client` and `invoice` - for example`client.invoices.show` or `client.invoices.create` - sounds more natural and intuitive than singular one (`client.invoice.show`, `client.invoice.create`).
